### PR TITLE
chore: migrate jdfalk/ refs to falkcorp/ org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   # Check for commit override flags
   check-overrides:
     name: Check Commit Overrides
-    uses: jdfalk/ghcommon/.github/workflows/commit-override-handler.yml@378e23a96c00d719075732dd2af4de45f7523cbb # v1.10.4
+    uses: falkcorp/github-common/.github/workflows/commit-override-handler.yml@378e23a96c00d719075732dd2af4de45f7523cbb # v1.10.4
 
   # Detect what files changed to optimize workflow execution
   detect-changes:

--- a/.github/workflows/sync-receiver.yml
+++ b/.github/workflows/sync-receiver.yml
@@ -4,7 +4,7 @@
 
 # ⚠️  DO NOT EDIT DIRECTLY - This file is managed in ghcommon repository
 # All changes should be made in jdfalk/ghcommon and will be synced to other repositories
-# Edit this file at: https://github.com/jdfalk/ghcommon/edit/main/.github/workflows/sync-receiver.yml
+# Edit this file at: https://github.com/falkcorp/github-common/edit/main/.github/workflows/sync-receiver.yml
 
 name: Sync Receiver (DISABLED)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
   * Stdio transport for compatibility with Claude Desktop, Continue.dev, and GitHub Copilot
   * Tool wrappers for git, buf, and python commands
   * Comprehensive security enforcement and timeout handling
-  * Repository: <https://github.com/jdfalk/safe-ai-util-mcp>
+  * Repository: <https://github.com/falkcorp/safe-ai-util-mcp>
 
 ### Documentation
 

--- a/MIGRATION_STATUS.md
+++ b/MIGRATION_STATUS.md
@@ -21,7 +21,7 @@ This document tracks the three-objective migration:
 ### Repository Creation
 
 * [x] **Create repo via gh CLI**
-  * Command: `gh repo create jdfalk/safe-ai-util-mcp --public --description "MCP server for safe-ai-util - exposes AI-safe command execution tools via ModelContext Protocol"`
+  * Command: `gh repo create falkcorp/safe-ai-util-mcp --public --description "MCP server for safe-ai-util - exposes AI-safe command execution tools via ModelContext Protocol"`
   * Status: Not started
   * Blocker: None
 
@@ -51,7 +51,7 @@ This document tracks the three-objective migration:
 ### Initial Repository Setup
 
 * [x] **Clone locally**
-  * Location: `/Users/jdfalk/repos/github.com/jdfalk/safe-ai-util-mcp`
+  * Location: `/Users/jdfalk/repos/github.com/falkcorp/safe-ai-util-mcp`
   * Status: Not started
 
 * [x] **Initial commit**
@@ -66,7 +66,7 @@ This document tracks the three-objective migration:
 
 * [ ] **Rename via gh CLI or web**
   * Old: `jdfalk/copilot-agent-util-rust`
-  * New: `jdfalk/safe-ai-util`
+  * New: `falkcorp/safe-ai-util`
   * Method: `gh repo rename safe-ai-util` (from repo directory)
   * Status: Not started
   * Note: GitHub auto-redirects old URLs

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cargo install copilot-agent-util
 ### From GitHub
 
 ```bash
-git clone https://github.com/jdfalk/safe-ai-util.git
+git clone https://github.com/falkcorp/safe-ai-util.git
 cd safe-ai-util
 cargo build --release
 cargo install --path .
@@ -76,7 +76,7 @@ cargo install --path .
 
 ### From Binary Releases
 
-Download pre-compiled binaries from the [releases page](https://github.com/jdfalk/safe-ai-util/releases).
+Download pre-compiled binaries from the [releases page](https://github.com/falkcorp/safe-ai-util/releases).
 Release artifacts include both names, e.g. `copilot-agent-util-macos-arm64` and `safe-ai-util-macos-arm64`.
 
 ## Usage


### PR DESCRIPTION
## Migrate org references: jdfalk → falkcorp

Automated PR to update all workflow `uses:` references, Go module paths, and GHCR image tags
from `jdfalk/` to `falkcorp/` as part of the organization migration.

### Changed files:
- `.github/workflows/ci.yml`
- `MIGRATION_STATUS.md`
- `CHANGELOG.md`
- `README.md`
- `.github/workflows/sync-receiver.yml`

🤖 Generated by `scripts/org-migration/update-workflow-refs.py`