### PR TITLE
chore(standards): add .standards submodule and centralize AI instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,89 +1,30 @@
 <!-- file: .github/copilot-instructions.md -->
-<!-- version: 2.3.2 -->
+<!-- version: 2.4.0 -->
 <!-- guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a -->
+<!-- last-edited: 2026-06-13 -->
 
-# GitHub Common Workflows Repository - AI Agent Instructions
+# safe-ai-util — Additional Context
 
-This repository serves as the **central infrastructure hub** for reusable GitHub Actions workflows, scripts, and configurations across multiple repositories. It implements a sophisticated modular instruction system and provides automation tools for multi-repository management.
+Org-wide coding standards (file headers, language rules, commit format) are at
+**https://github.com/falkcorp/.github** and apply automatically to this repo.
 
-## 🏗️ Repository Architecture
+For full project context: **CLAUDE.md** at the repo root.
 
-**This is a workflow infrastructure repository**, not a typical application codebase. Key architectural components:
+## Project overview
 
-- **Reusable Workflows**: `.github/workflows/reusable-*.yml` - Called by other repositories
-- **Script Library**: `scripts/` - Python automation tools for cross-repo operations
-- **Instruction System**: `.github/instructions/` - Modular AI agent rules with language targeting
-- **Workflow Debugging**: `scripts/workflow-debugger.py` - Analyzes failures and generates fix tasks
-- **Multi-Repo Sync**: `scripts/intelligent_sync_to_repos.py` - Propagates changes to target repos
+Safe centralized utility for AI agent command execution with comprehensive logging. Language: Rust/Python.
 
-## 🔧 Critical AI Agent Workflows
+## Key directories
 
-Use VS Code tasks for non-git operations (build, lint, generate). For git operations, prefer:
-1) MCP GitHub tools (preferred), 2) safe-ai-util (fallback), 3) native git (last resort).
+| Directory | Purpose |
+|-----------|---------|
+| `src/` | Rust source code |
+| `scripts/` | Python automation scripts |
+| `tests/` | Integration tests |
+| `docs/` | Documentation |
 
-Use specialized subagents when possible: CI Workflow Doctor, Dependency Auditor, Documentation Curator, Git Hygiene Guardian, Lint & Format Conductor, Protobuf Builder, Protobuf Cycle Resolver, and others in `.github/prompts/` for targeted expertise.
+## Critical constraints
 
-### Protobuf Operations (Core Focus)
-```bash
-# Use tasks, not manual buf commands
-"Buf Generate with Output" - Generates protobuf code with logging
-"Buf Lint with Output" - Lints protobuf files with comprehensive output
-```
-- This repo heavily focuses on protobuf tooling and cross-repo protobuf management
-- Use `tools/protobuf-cycle-fixer.py` for import cycle resolution
-- Protobuf changes trigger the `protobuf-generation.yml` workflow
-
-### Git Operations (Policy)
-- Prefer MCP GitHub tools or safe-ai-util for all git actions (add/commit/push).
-- Avoid VS Code git tasks; keep git automation out of editor tasks.
-- All commits MUST use conventional commit format: `type(scope): description`.
-- See `.github/instructions/commit-messages.instructions.md` for detailed commit message rules.
-
-## 🎯 Multi-Repository Management Patterns
-
-**This repository manages configurations for multiple target repositories:**
-
-### Sync Operations
-```bash
-# Primary sync script for propagating changes
-python scripts/intelligent_sync_to_repos.py --target-repos "repo1,repo2" --dry-run
-```
-- Syncs `.github/instructions/`, `.github/prompts/`, and workflows to target repos
-- Creates VS Code Copilot symlinks: `.vscode/copilot/` → `.github/instructions/`
-- Handles repository-specific file exclusions and maintains file headers
-
-### Workflow Debugging & Auto-Fix
-```bash
-python scripts/workflow-debugger.py --org jdfalk --scan-all --fix-tasks
-```
-- Analyzes workflow failures across repositories
-- Generates JSON fix tasks for Copilot agents at `workflow-debug-output/fix-tasks/`
-- Categorizes failures: permissions, dependencies, syntax, infrastructure
-- Outputs actionable remediation steps with code examples
-
-## 📁 File Organization Conventions
-
-**Modular Instruction System** (referenced by general instructions):
-- `general-coding.instructions.md` - Base rules for all languages
-- `{language}.instructions.md` - Language-specific extensions with `applyTo: "**/*.{ext}"` frontmatter
-- Instructions are synced to target repos and symlinked for VS Code Copilot integration
-
-**Repository-Specific Patterns**:
-- All files require versioned headers: `<!-- file: path -->`, `<!-- version: x.y.z -->`, `<!-- guid: uuid -->`
-- Always increment version numbers on file changes (patch/minor/major semantic versioning)
-- Use `copilot-util-args` file for storing command arguments between task executions
-
-## 🔍 Project-Specific Context
-
-**This is an infrastructure repository** - focus on:
-1. **Workflow reliability** - Use workflow debugger to identify and fix cross-repo workflow issues
-2. **Protobuf tooling** - Buf integration, cycle detection, and cross-repo protobuf synchronization
-3. **Configuration propagation** - Ensure changes sync correctly to target repositories
-4. **Agent task generation** - Workflow debugger creates structured tasks for AI agents
-
-**Common Operations**:
-- Analyze workflow failures: `scripts/workflow-debugger.py`
-- Sync to repositories: `scripts/intelligent_sync_to_repos.py`
-- Fix protobuf cycles: `tools/protobuf-cycle-fixer.py`Always check `logs/` directory after running VS Code tasks for execution details and debugging information.
-
-For detailed coding rules, see `.github/instructions/general-coding.instructions.md` and language-specific instruction files.
+- Use `copilot-agent-util` (this binary) for git operations in agent workflows — not raw git
+- All commits MUST use conventional commit format: `type(scope): description`
+- Logs are written to `logs/` after running VS Code tasks

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".standards"]
+	path = .standards
+	url = https://github.com/falkcorp/.github

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,52 +1,11 @@
 <!-- file: AGENTS.md -->
-<!-- version: 2.2.2 -->
+<!-- version: 3.0.0 -->
 <!-- guid: 2e7c1a4b-5d3f-4b8c-9e1f-7a6b2c3d4e5f -->
+<!-- last-edited: 2026-06-13 -->
 
 # AGENTS.md
 
-> **NOTE:** This is a pointer file. All detailed Copilot, agent, and workflow instructions are in
-> the [.github/](.github/) directory.
+See **CLAUDE.md** for all agent instructions and project context.
 
-## 🚨 CRITICAL: Documentation Update Protocol
-
-This repository uses a direct-edit documentation workflow. The legacy doc-update scripts and
-workflows are retired.
-
-- Edit documentation directly in the target files.
-- Always keep the required header (file path, version, guid) and bump the version on any change.
-- Do not use create-doc-update.sh, doc_update_manager.py, or .github/doc-updates/.
-- Prefer VS Code tasks for git operations (Git Add All, Git Commit, Git Push) when available.
-  - These tasks use the `copilot-agent-util` Rust utility for enhanced logging, error handling, and
-    safety.
-  - Download: <https://github.com/jdfalk/copilot-agent-util-rust/releases/latest>
-
-## ⚠️ CRITICAL: File Version Updates
-
-**When modifying any file with a version header, ALWAYS update the version number:**
-
-- **Patch version** (x.y.Z): Bug fixes, typos, minor formatting changes
-- **Minor version** (x.Y.z): New features, significant content additions, template changes
-- **Major version** (X.y.z): Breaking changes, structural overhauls, format changes
-
-**Examples:**
-
-- Fix typo: `1.2.3` → `1.2.4`
-- Add new section: `1.2.3` → `1.3.0`
-- Change template structure: `1.2.3` → `2.0.0`
-
-**This applies to ALL files with version headers including documentation, templates, and
-configuration files.**
-
-## Key Copilot/Agent Documents
-
-- [Copilot Instructions](.github/copilot-instructions.md)
-- [Commit Message Standards](.github/commit-messages.md)
-- [Pull Request Description Guidelines](.github/pull-request-descriptions.md)
-- [Code Review Guidelines](.github/review-selection.md)
-- [Test Generation Guidelines](.github/test-generation.md)
-- [Security Guidelines](.github/security-guidelines.md)
-- [Repository Setup Guide](.github/repository-setup.md)
-- [Workflow Usage](.github/workflow-usage.md)
-- [All Code Style Guides](.github/)
-
-> For any agent, Copilot, or workflow task, **always refer to the above files.**
+Org-wide coding standards (file headers, language rules, commit format):
+**https://github.com/falkcorp/.github**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,22 @@
 <!-- file: CLAUDE.md -->
-<!-- version: 2.2.0 -->
+<!-- version: 2.3.0 -->
 <!-- guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f -->
+<!-- last-edited: 2026-06-13 -->
 
 # CLAUDE.md
 
-> **NOTE:** This file is a pointer. All Claude/AI agent and workflow instructions are now
-> centralized in the `.github/instructions/` and `.github/prompts/` directories.
+Safe centralized utility for AI agent command execution with comprehensive logging. Language: Rust/Python.
+
+## Coding Standards
+
+Org-wide coding standards are in the `.standards/` git submodule (cloned from `https://github.com/falkcorp/.github`).
+Always clone with `git clone --recurse-submodules` so these are available.
+
+Key files:
+- **File headers (MANDATORY):** `.standards/instructions/file-headers.md`
+- **Commit format:** `.standards/instructions/commit-messages.md`
+
+> **NOTE:** This file is the authoritative project instructions. See `.github/instructions/` and `.github/prompts/` for additional language-specific rules.
 
 ## 🚨 CRITICAL: Documentation Update Protocol
 


### PR DESCRIPTION
## Summary

- Adds `.standards/` git submodule → `falkcorp/.github` (org-wide coding standards)
- Slims `.github/copilot-instructions.md` to repo-specific stub only (removes template boilerplate)
- Creates/updates `CLAUDE.md` to reference `.standards/instructions/` for coding standards
- Updates `AGENTS.md` to redirect to `CLAUDE.md`

After merging: `git clone --recurse-submodules` auto-populates `.standards/` with coding standards.

## Test plan
- [ ] `.gitmodules` contains `.standards` → `https://github.com/falkcorp/.github`
- [ ] `copilot-instructions.md` is ≤25 lines and references CLAUDE.md
- [ ] `CLAUDE.md` has `## Coding Standards` section referencing `.standards/`