### PR TITLE
fix(clippy): resolve clippy warnings breaking CI

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/release-docker.yml
-# version: 1.0.3
+# version: 1.0.4
 # guid: a4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d
 
 name: Docker Release Build
@@ -103,7 +103,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix={{branch}}-,enable={{is_default_branch}}
           labels: |
             org.opencontainers.image.title=${{ github.repository }}
             org.opencontainers.image.description=Container for ${{ github.repository }}

--- a/src/commands/awk.rs
+++ b/src/commands/awk.rs
@@ -1,5 +1,5 @@
 // file: src/commands/awk.rs
-// version: 1.0.0
+// version: 1.0.1
 // guid: 9b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e
 
 use crate::executor::Executor;
@@ -53,8 +53,7 @@ pub async fn execute(matches: &ArgMatches, _executor: &Executor) -> Result<()> {
         .map(|vals| vals.cloned().collect())
         .unwrap_or_default();
 
-    let field_separator = matches.get_one::<String>("field-separator")
-        .map(|s| s.clone())
+    let field_separator = matches.get_one::<String>("field-separator").cloned()
         .unwrap_or_else(|| " ".to_string());
 
     let assignments = matches.get_many::<String>("assign")
@@ -351,14 +350,14 @@ fn parse_action(action_text: &str) -> Result<AwkAction> {
             return Ok(AwkAction::Print(None));
         }
 
-        if inner.starts_with("print ") {
-            let expr = inner[6..].trim().to_string();
+        if let Some(stripped) = inner.strip_prefix("print ") {
+            let expr = stripped.trim().to_string();
             return Ok(AwkAction::Print(Some(expr)));
         }
 
-        if inner.starts_with("printf ") {
+        if let Some(stripped) = inner.strip_prefix("printf ") {
             // Simple printf parsing
-            let args = inner[7..].trim();
+            let args = stripped.trim();
             return Ok(AwkAction::PrintF(args.to_string(), Vec::new()));
         }
 
@@ -459,8 +458,7 @@ fn evaluate_expression(expr: &str, context: &AwkContext, line: &str) -> Result<b
     }
 
     // Handle simple field references
-    if expr.starts_with('$') {
-        let field_num_str = &expr[1..];
+    if let Some(field_num_str) = expr.strip_prefix('$') {
         if let Ok(field_num) = field_num_str.parse::<usize>() {
             let field_value = context.get_field(field_num);
             return Ok(!field_value.is_empty());
@@ -475,8 +473,7 @@ fn evaluate_expression(expr: &str, context: &AwkContext, line: &str) -> Result<b
 fn evaluate_field_or_variable(expr: &str, context: &AwkContext) -> Result<String> {
     let expr = expr.trim();
 
-    if expr.starts_with('$') {
-        let field_ref = &expr[1..];
+    if let Some(field_ref) = expr.strip_prefix('$') {
         if let Ok(field_num) = field_ref.parse::<usize>() {
             Ok(context.get_field(field_num))
         } else {

--- a/src/commands/buf.rs
+++ b/src/commands/buf.rs
@@ -1,5 +1,5 @@
 // file: src/commands/buf.rs
-// version: 1.1.0
+// version: 1.1.1
 // guid: 7e8f9a0b-1c2d-3e4f-5a6b-7c8d9e0f1a2b
 
 use crate::executor::Executor;
@@ -194,12 +194,10 @@ async fn execute_format(matches: &ArgMatches, executor: &Executor) -> Result<()>
 
 async fn execute_breaking(matches: &ArgMatches, executor: &Executor) -> Result<()> {
     let against = matches.get_one::<String>("against").unwrap();
-    let args = vec![
-        "buf".to_string(),
+    let args = ["buf".to_string(),
         "breaking".to_string(),
         "--against".to_string(),
-        against.clone(),
-    ];
+        against.clone()];
 
     info!("Checking for breaking changes against: {}", against);
     executor.execute_secure("buf", &args[1..]).await
@@ -207,7 +205,7 @@ async fn execute_breaking(matches: &ArgMatches, executor: &Executor) -> Result<(
 
 async fn execute_build(matches: &ArgMatches, executor: &Executor) -> Result<()> {
     let path = matches.get_one::<String>("path").unwrap();
-    let args = vec!["buf".to_string(), "build".to_string(), path.clone()];
+    let args = ["buf".to_string(), "build".to_string(), path.clone()];
 
     info!("Building protocol buffers at path: {}", path);
     executor.execute_secure("buf", &args[1..]).await

--- a/src/commands/prettier.rs
+++ b/src/commands/prettier.rs
@@ -1,5 +1,5 @@
 // file: src/commands/prettier.rs
-// version: 1.0.0
+// version: 1.0.1
 // guid: f3b23e72-ff46-4cdd-bba2-9f14cede3837
 
 use crate::executor::Executor;
@@ -493,7 +493,7 @@ async fn execute_yaml_format(matches: &ArgMatches, executor: &Executor) -> Resul
     let indent = matches.get_one::<String>("indent").unwrap();
 
     // Using yq for YAML formatting
-    let args = vec!["yq", "eval", ".", "--indent", indent, path];
+    let args = ["yq", "eval", ".", "--indent", indent, path];
 
     info!("Running YAML format on: {}", path);
     match args.first() {
@@ -510,7 +510,7 @@ async fn execute_json_format(matches: &ArgMatches, executor: &Executor) -> Resul
     let indent = matches.get_one::<String>("indent").unwrap();
 
     // Using jq for JSON formatting
-    let args = vec!["jq", "--indent", indent, ".", path];
+    let args = ["jq", "--indent", indent, ".", path];
 
     info!("Running JSON format on: {}", path);
     match args.first() {

--- a/src/commands/sed.rs
+++ b/src/commands/sed.rs
@@ -1,5 +1,5 @@
 // file: src/commands/sed.rs
-// version: 1.0.0
+// version: 1.0.1
 // guid: 8a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
 
 use crate::executor::Executor;
@@ -357,7 +357,7 @@ fn process_input_to_writer<W: Write>(
                             if count == n {
                                 replacement.clone()
                             } else {
-                                return format!("{}", &line_str); // This is wrong, need to fix
+                                line_str.to_string()// This is wrong, need to fix
                             }
                         }).to_string();
                     } else {

--- a/src/security/audit.rs
+++ b/src/security/audit.rs
@@ -1,5 +1,5 @@
 // file: src/security/audit.rs
-// version: 1.0.0
+// version: 1.0.1
 // guid: d4e5f6a7-b8c9-0123-def4-456789012345
 
 //! Security audit logging module
@@ -269,11 +269,10 @@ pub fn cleanup_old_audit_logs() -> std::io::Result<()> {
                     if let Ok(metadata) = std::fs::metadata(&path) {
                         if let Ok(modified) = metadata.modified() {
                             let modified_datetime: DateTime<Utc> = modified.into();
-                            if modified_datetime < cutoff {
-                                if std::fs::remove_file(&path).is_ok() {
+                            if modified_datetime < cutoff
+                                && std::fs::remove_file(&path).is_ok() {
                                     removed_count += 1;
                                 }
-                            }
                         }
                     }
                 }

--- a/src/security/validator.rs
+++ b/src/security/validator.rs
@@ -1,5 +1,5 @@
 // file: src/security/validator.rs
-// version: 1.0.0
+// version: 1.0.1
 // guid: c3d4e5f6-a7b8-9012-cdef-345678901234
 
 //! Command validation module
@@ -307,13 +307,12 @@ fn validate_docker_run_args(args: &[String]) -> Result<()> {
         if arg.starts_with("--user") && arg.contains("root") {
             warn!("Docker run as root user detected");
         }
-        if arg.starts_with("--volume") || arg.starts_with("-v") {
-            if arg.contains(":/") {
+        if (arg.starts_with("--volume") || arg.starts_with("-v"))
+            && arg.contains(":/") {
                 return Err(AgentError::security(
                     "Docker volume mount to root filesystem is not allowed"
                 ));
             }
-        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Replace manual prefix slicing with `strip_prefix()` in `awk.rs` (clippy::manual_strip)
- Replace `vec![...]` with array literals/slices in `buf.rs`, `prettier.rs`, `security/mod.rs` (clippy::useless_vec)
- Replace `format!("{}", x)` with `.to_string()` in `sed.rs` (clippy::useless_format)
- Collapse nested `if` blocks in `security/audit.rs` and `security/validator.rs` (clippy::collapsible_if)
- Guard the `type=sha,prefix={{branch}}-` Docker metadata tag with `enable={{is_default_branch}}` in `release-docker.yml` to fix the invalid `:-<sha>` tag on PR builds

The same Docker tag fix has already been applied to `apt-cacher-go` and `gcommon-proto` directly.

## Test plan

- [ ] `cargo clippy -- -D warnings` passes locally (verified)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ta4Dmk5dfyGDskojqQpvjX