### PR TITLE
fix(docker): repair the container build end to end

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,7 +29,10 @@ docs/
 
 # Rust
 target/
-Cargo.lock
+# NOTE: Cargo.lock must NOT be ignored. This is a binary crate, so the lock file
+# is committed and the Dockerfile copies it (COPY Cargo.toml Cargo.lock ./) for
+# a reproducible build. Excluding it here made that COPY fail with
+# '"/Cargo.lock": not found'.
 **/*.rs.bk
 *.pdb
 
@@ -49,7 +52,9 @@ dist/
 # Scripts
 scripts/
 examples/
-benches/
+# NOTE: benches/ must NOT be ignored. Cargo.toml declares a [[bench]] target at
+# benches/executor_benchmark.rs, and cargo refuses to parse the manifest at all
+# when that path is absent. tests/ has no such declaration, so it stays out.
 tests/
 
 # Temporary files

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,15 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Create app user
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --home "/nonexistent" \
-    --shell "/sbin/nologin" \
+# Create app user. Uses useradd, not adduser: the rust:1.97-slim base is Debian
+# 13 (trixie), whose slim images no longer ship the adduser wrapper, so the old
+# invocation failed with exit 127 (command not found). useradd is in the image.
+RUN useradd \
     --no-create-home \
-    --uid "10001" \
+    --home-dir "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --comment "" \
+    --uid 10001 \
     appuser
 
 WORKDIR /app
@@ -26,15 +27,21 @@ WORKDIR /app
 # Copy manifests
 COPY Cargo.toml Cargo.lock ./
 
-# Copy source code
+# Copy source code. benches/ is required too: Cargo.toml declares a [[bench]]
+# target at benches/executor_benchmark.rs, and cargo fails to even parse the
+# manifest when that path is missing ("can't find `executor_benchmark` bench").
 COPY src ./src
+COPY benches ./benches
 
 # Build the application
 RUN cargo build --release && \
     strip target/release/copilot-agent-util
 
 # Runtime stage
-FROM debian:bookworm-slim
+# Must match the builder's Debian release. The builder is rust:1.97-slim, which
+# is Debian 13 (trixie, glibc 2.41); on bookworm (Debian 12, glibc 2.36) the
+# binary built above fails at startup with "GLIBC_2.39 not found".
+FROM debian:trixie-slim
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \

--- a/changelog.d/20260720-docker-build-repair.md
+++ b/changelog.d/20260720-docker-build-repair.md
@@ -1,0 +1,9 @@
+### Fixed
+
+#### The container image builds, and the binary in it runs
+
+Four faults, each hidden behind the previous: `.dockerignore` excluded the
+`Cargo.lock` the Dockerfile copies; `adduser` no longer exists in the Debian 13
+base; `benches/` was required by a `[[bench]]` declaration but never copied; and
+the runtime stage ran an older Debian than the builder, so the image built
+cleanly while the binary died with "GLIBC_2.39 not found".


### PR DESCRIPTION
## Summary

The Docker jobs are red on `main`. There were **four** separate faults, each
hidden behind the previous one — I only found them by running the build locally
and fixing forward until the image actually worked.

| # | Fault | Symptom |
|---|---|---|
| 1 | `.dockerignore` excluded `Cargo.lock` while the Dockerfile does `COPY Cargo.toml Cargo.lock ./` | `"/Cargo.lock": not found` while computing the cache key |
| 2 | `adduser` doesn't exist in `rust:1.97-slim` (now Debian 13 trixie, which dropped the wrapper) | exit code 127 |
| 3 | `Cargo.toml` declares `[[bench]]` at `benches/executor_benchmark.rs`, but `benches/` was neither copied nor allowed by `.dockerignore` | cargo refuses to parse the manifest |
| 4 | Runtime stage was `debian:bookworm-slim` (glibc 2.36) while the builder is trixie (glibc 2.41) | image builds fine, **binary dies at startup** |

**Fault 4 is the one CI could never have caught** — the build succeeds and the
artifact is broken:

```
copilot-agent-util: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

## Changes

- `.dockerignore`: stop ignoring `Cargo.lock` and `benches/` (both with comments
  explaining why they must stay). `tests/` has no `[[test]]` declaration, so it
  remains excluded.
- `Dockerfile`: `adduser` → `useradd`; `COPY benches ./benches`; runtime base →
  `debian:trixie-slim`.

## Testing

Verified with a **real end-to-end build**, not just inspection:

- Full image builds successfully.
- `docker run --rm <image> --version` now **starts the binary**, which previously
  failed on the glibc mismatch.
- The `useradd` swap produces an identical account:
  `appuser:x:10001:10001::/nonexistent:/sbin/nologin`

Found while fanning out the TODO fragment system (#19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vU67T2LJDCbYTBs9ZFAf2