### PR TITLE
docs(agents): document changelog/TODO fragment system for AI agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 <!-- file: .github/copilot-instructions.md -->
-<!-- version: 2.4.0 -->
+<!-- version: 2.5.0 -->
 <!-- guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a -->
-<!-- last-edited: 2026-06-13 -->
+<!-- last-edited: 2026-07-21 -->
 
 # safe-ai-util — Additional Context
 
@@ -28,3 +28,20 @@ Safe centralized utility for AI agent command execution with comprehensive loggi
 - Use `copilot-agent-util` (this binary) for git operations in agent workflows — not raw git
 - All commits MUST use conventional commit format: `type(scope): description`
 - Logs are written to `logs/` after running VS Code tasks
+
+
+## 📝 Changelog & TODO — Use the Fragment System (MANDATORY)
+
+**Do not hand-edit `CHANGELOG.md`, and do not add new tasks straight into the
+`TODO.md` inbox.** Both files are assembled from per-change fragments so that
+parallel PRs never collide on them.
+
+- **`CHANGELOG.md` is assembled, not hand-edited.** Add a fragment under
+  `changelog.d/` (run `scriv create`, or write the Markdown file by hand). The
+  fragments are folded into `CHANGELOG.md` at release time by `scriv`, and a CI
+  check (`changelog-check.yml`) requires one on each PR. See `changelog.d/README.md`.
+- **New `TODO.md` tasks are added via fragments.** Drop a Markdown fragment in
+  `todo.d/` (see `todo.d/README.md`) instead of editing the `## 📥 Inbox`
+  section. `scripts/assemble_todo.py` folds fragments in daily. This is
+  **add-only**: checking a task off or removing it is a normal direct edit of
+  `TODO.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- file: CLAUDE.md -->
-<!-- version: 2.3.0 -->
+<!-- version: 2.4.0 -->
 <!-- guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f -->
-<!-- last-edited: 2026-06-13 -->
+<!-- last-edited: 2026-07-21 -->
 
 # CLAUDE.md
 
@@ -42,3 +42,20 @@ workflows are retired.
 
 For all agent, Claude, or workflow tasks, **refer to the above files**. Do not duplicate or override
 these rules elsewhere.
+
+
+## 📝 Changelog & TODO — Use the Fragment System (MANDATORY)
+
+**Do not hand-edit `CHANGELOG.md`, and do not add new tasks straight into the
+`TODO.md` inbox.** Both files are assembled from per-change fragments so that
+parallel PRs never collide on them.
+
+- **`CHANGELOG.md` is assembled, not hand-edited.** Add a fragment under
+  `changelog.d/` (run `scriv create`, or write the Markdown file by hand). The
+  fragments are folded into `CHANGELOG.md` at release time by `scriv`, and a CI
+  check (`changelog-check.yml`) requires one on each PR. See `changelog.d/README.md`.
+- **New `TODO.md` tasks are added via fragments.** Drop a Markdown fragment in
+  `todo.d/` (see `todo.d/README.md`) instead of editing the `## 📥 Inbox`
+  section. `scripts/assemble_todo.py` folds fragments in daily. This is
+  **add-only**: checking a task off or removing it is a normal direct edit of
+  `TODO.md`.

--- a/changelog.d/document-fragment-system-for-agents.md
+++ b/changelog.d/document-fragment-system-for-agents.md
@@ -1,0 +1,8 @@
+### Changed
+
+#### Document the changelog/TODO fragment system for AI agents
+
+`CLAUDE.md` and `.github/copilot-instructions.md` now instruct AI agents to use
+the `changelog.d/` and `todo.d/` fragment systems instead of editing
+`CHANGELOG.md` or the `TODO.md` inbox directly, preventing parallel-PR
+collisions on those files.


### PR DESCRIPTION
## Summary

The `changelog.d/` and `todo.d/` fragment systems are set up in this repo, but nothing in `CLAUDE.md` or `.github/copilot-instructions.md` told AI agents to use them — so an agent would edit `CHANGELOG.md` / the `TODO.md` inbox directly and hit merge conflicts.

Adds a self-contained **"Changelog & TODO — Use the Fragment System (MANDATORY)"** section to both files (creating either if the repo lacked it).

## Changes
- `CLAUDE.md` — append section (or create); bump version
- `.github/copilot-instructions.md` — append section (or create); bump version
- `changelog.d/` — fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)